### PR TITLE
Fix for updated a1111 ui

### DIFF
--- a/javascript/naiprompt2webui.js
+++ b/javascript/naiprompt2webui.js
@@ -46,7 +46,10 @@ function round(value) {
 }
 function convert(input) {
   const re_attention = /\{|\[|\}|\]|[^\{\}\[\]]+/gmu;
-  let text = input.replaceAll("(", "\\(").replaceAll(")", "\\)").replace(/\\{2,}(\(|\))/gim,'\\$1');
+  let text = input
+    .replaceAll("(", "\\(")
+    .replaceAll(")", "\\)")
+    .replace(/\\{2,}(\(|\))/gim, "\\$1");
 
   let res = [];
 
@@ -184,11 +187,11 @@ function onClickUndo() {
 }
 
 onUiUpdate(function () {
-  let parentArea = gradioApp().querySelector("#toprow");
+  let parentArea = gradioApp().querySelector("#txt2img_toprow");
   let generateBtn = gradioApp().querySelector("#txt2img_generate");
-  let beforeElement = gradioApp().querySelector("#roll_col");
+  let actionsColumn = gradioApp().querySelector("#txt2img_actions_column");
 
-  if (parentArea == null || generateBtn == null || beforeElement == null)
+  if (parentArea == null || generateBtn == null || actionsColumn == null)
     return;
   if (gradioApp().querySelector("#nai2local") != null) return;
 
@@ -196,9 +199,8 @@ onUiUpdate(function () {
 
   let nai2LocalArea = document.createElement("div");
   nai2LocalArea.id = "nai2local";
-  nai2LocalArea.className = "overflow-hidden flex flex-col relative col gap-4";
-  nai2LocalArea.style =
-    "min-width: min(110px, 100%); max-width: 120px; flex-grow: 1; padding: 0em; padding-top: 0.4em;";
+  nai2LocalArea.className = "overflow-hidden flex col gap-4";
+  nai2LocalArea.style = "padding: 0.4em 0em";
 
   let convertBtn = document.createElement("button");
   convertBtn.id = "nai2localconvert";
@@ -220,5 +222,5 @@ onUiUpdate(function () {
   undoBtn.addEventListener("click", onClickUndo);
   nai2LocalArea.appendChild(undoBtn);
 
-  parentArea.insertBefore(nai2LocalArea, beforeElement.nextSibling);
+  actionsColumn.append(nai2LocalArea);
 });

--- a/javascript/naiprompt2webui.js
+++ b/javascript/naiprompt2webui.js
@@ -186,40 +186,40 @@ function onClickUndo() {
   negprompt.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
-onUiUpdate(function () {
-  let parentArea = gradioApp().querySelector("#txt2img_toprow");
-  let generateBtn = gradioApp().querySelector("#txt2img_generate");
-  let actionsColumn = gradioApp().querySelector("#txt2img_actions_column");
+function createButton(id, innerHTML, onClick) {
+  const button = document.createElement("button");
+  button.id = id;
+  button.type = "button";
+  button.innerHTML = innerHTML;
+  button.className = "gr-button gr-button-lg gr-button-secondary";
+  button.style = `padding-left: 0.1em; padding-right: 0em; margin: 0.1em 0;max-height: 2em; max-width: 6em`;
+  button.addEventListener("click", onClick);
+  return button;
+}
 
-  if (parentArea == null || generateBtn == null || actionsColumn == null)
-    return;
-  if (gradioApp().querySelector("#nai2local") != null) return;
+onUiUpdate(() => {
+  const parentArea = gradioApp().querySelector("#txt2img_toprow");
+  const generateBtn = gradioApp().querySelector("#txt2img_generate");
+  const actionsColumn = gradioApp().querySelector("#txt2img_actions_column");
+  const nai2local = gradioApp().querySelector("#nai2local");
+
+  if (!parentArea || !generateBtn || !actionsColumn || nai2local) return;
 
   generateBtn.addEventListener("click", onClickGenerate);
 
-  let nai2LocalArea = document.createElement("div");
+  const nai2LocalArea = document.createElement("div");
   nai2LocalArea.id = "nai2local";
   nai2LocalArea.className = "overflow-hidden flex col gap-4";
   nai2LocalArea.style = "padding: 0.4em 0em";
 
-  let convertBtn = document.createElement("button");
-  convertBtn.id = "nai2localconvert";
-  convertBtn.type = "button";
-  convertBtn.innerHTML = "NAIConvert";
-  convertBtn.className = "gr-button gr-button-lg gr-button-secondary";
-  convertBtn.style =
-    "padding-left: 0.1em; padding-right: 0em; margin: 0.1em 0;max-height: 2em; max-width: 6em";
-  convertBtn.addEventListener("click", onClickConvert);
-  nai2LocalArea.appendChild(convertBtn);
+  const convertBtn = createButton(
+    "nai2localconvert",
+    "NAIConvert",
+    onClickConvert
+  );
+  const undoBtn = createButton("nai2localUndo", "History", onClickUndo);
 
-  let undoBtn = document.createElement("button");
-  undoBtn.id = "nai2localUndo";
-  undoBtn.type = "button";
-  undoBtn.innerHTML = "History";
-  undoBtn.className = "gr-button gr-button-lg gr-button-secondary";
-  undoBtn.style =
-    "padding-left: 0.1em; padding-right: 0em; margin: 0.1em 0;max-height: 2em; max-width: 6em";
-  undoBtn.addEventListener("click", onClickUndo);
+  nai2LocalArea.appendChild(convertBtn);
   nai2LocalArea.appendChild(undoBtn);
 
   actionsColumn.append(nai2LocalArea);

--- a/javascript/naiprompt2webui.js
+++ b/javascript/naiprompt2webui.js
@@ -119,6 +119,12 @@ function convert(input) {
   return result;
 }
 
+function dispatchInputEvent(target) {
+  let inputEvent = new Event("input");
+  Object.defineProperty(inputEvent, "target", { value: target });
+  target.dispatchEvent(inputEvent);
+}
+
 function onClickConvert() {
   const default_prompt = "masterpiece, best quality,\n";
   const default_negative =
@@ -134,7 +140,7 @@ function onClickConvert() {
     }
   }
   prompt.value = result;
-  prompt.dispatchEvent(new Event("input", { bubbles: true }));
+  dispatchInputEvent(prompt);
 
   result = "";
   let negprompt = gradioApp().querySelector(
@@ -150,7 +156,7 @@ function onClickConvert() {
     result = default_negative;
   }
   negprompt.value = result;
-  negprompt.dispatchEvent(new Event("input", { bubbles: true }));
+  dispatchInputEvent(negprompt);
 }
 
 function onClickGenerate() {
@@ -171,7 +177,7 @@ function onClickUndo() {
   } else {
     prompt.value = prePrompt;
   }
-  prompt.dispatchEvent(new Event("input", { bubbles: true }));
+  dispatchInputEvent(prompt);
 
   let negprompt = gradioApp().querySelector(
     "#txt2img_neg_prompt > label > textarea"
@@ -183,7 +189,7 @@ function onClickUndo() {
   } else {
     negprompt.value = prenegprompt;
   }
-  negprompt.dispatchEvent(new Event("input", { bubbles: true }));
+  dispatchInputEvent(negprompt);
 }
 
 function createButton(id, innerHTML, onClick) {
@@ -198,12 +204,11 @@ function createButton(id, innerHTML, onClick) {
 }
 
 onUiUpdate(() => {
-  const parentArea = gradioApp().querySelector("#txt2img_toprow");
   const generateBtn = gradioApp().querySelector("#txt2img_generate");
   const actionsColumn = gradioApp().querySelector("#txt2img_actions_column");
   const nai2local = gradioApp().querySelector("#nai2local");
 
-  if (!parentArea || !generateBtn || !actionsColumn || nai2local) return;
+  if (!generateBtn || !actionsColumn || nai2local) return;
 
   generateBtn.addEventListener("click", onClickGenerate);
 


### PR DESCRIPTION
Simple update to use the new ids in the a1111 ui, allowing the buttons to be added properly.
![image](https://user-images.githubusercontent.com/22661666/213947650-dd6fa4ec-edd1-432d-a96a-990d9d347a13.png)

I can remove the "improve readability" commit if you don't like it.